### PR TITLE
Add Install service section

### DIFF
--- a/templates/systemd-system-prometheus-node-exporter-service.j2
+++ b/templates/systemd-system-prometheus-node-exporter-service.j2
@@ -3,3 +3,6 @@ Description=Prometheus Node Exporter
 
 [Service]
 ExecStart=/opt/prometheus/node_exporter/node_exporter {{ prometheus_node_args | default('') }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is required for `systemctl enable`, otherwise the service will not be started after a reboot.