### PR TITLE
prometheus node exporter 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Prometheus node-exporter, defaults to listening on port 9100.
 Role Variables
 --------------
 
+All variables are optional:
+- `prometheus_node_version`: Prometheus Node version
+- `prometheus_node_sha256`: SHA256 checksum for the Linux amd64 download
 - `prometheus_node_args`: Arguments passed on the command line.
   See https://github.com/prometheus/node_exporter/ for configuration information.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults for prometheus-node
+
+prometheus_node_version: 1.0.1
+prometheus_node_sha256:
+  3369b76cd2b0ba678b6d618deab320e565c3d93ccb5c2a0d5db51a53857768ae
+
+prometheus_node_args: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,9 @@
     path: /opt/prometheus/node_exporter
     force: true
     state: link
+  notify:
+    - reload systemd
+    - restart prometheus-node-exporter
 
 - name: prometheus node | systemd service
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,8 @@
   become: true
   get_url:
     url: "https://github.com/prometheus/node_exporter/releases/download/\
-      v{{ prometheus_node_version }}/node_exporter-0.15.2.linux-amd64.tar.gz"
+      v{{ prometheus_node_version }}/node_exporter-{{ prometheus_node_version
+      }}.linux-amd64.tar.gz"
     checksum: "sha256:{{ prometheus_node_sha256 }}"
     dest: "/opt/prometheus/\
       node_exporter-{{ prometheus_node_version }}.linux-amd64.tar.gz"

--- a/templates/systemd-system-prometheus-node-exporter-service.j2
+++ b/templates/systemd-system-prometheus-node-exporter-service.j2
@@ -2,7 +2,7 @@
 Description=Prometheus Node Exporter
 
 [Service]
-ExecStart=/opt/prometheus/node_exporter/node_exporter {{ prometheus_node_args | default('') }}
+ExecStart=/opt/prometheus/node_exporter/node_exporter {{ prometheus_node_args }}
 
 [Install]
 WantedBy=multi-user.target

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,0 @@
----
-# vars for prometheus-node
-
-prometheus_node_version: 0.15.2
-prometheus_node_sha256: >-
-  1ce667467e442d1f7fbfa7de29a8ffc3a7a0c84d24d7c695cc88b29e0752df37


### PR DESCRIPTION
Update to `1.0.1`
Contains breaking changes (several metrics are renamed): https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md

Version parameters are now fully overridable in defaults.yml which means this role can be made backwards compatible by pinning the previous version:
```yaml
prometheus_node_version: 0.15.2
prometheus_node_sha256: 1ce667467e442d1f7fbfa7de29a8ffc3a7a0c84d24d7c695cc88b29e0752df37
```

Tag: `0.3.0`